### PR TITLE
Feat/stdio transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # Flags
 LD_FLAGS  = \
-	-X axone-protocol/axone-mcp/internal/version.Name=$(BINARY_NAME) \
-	-X axone-protocol/axone-mcp/internal/version.Version=$(VERSION)  \
-	-X axone-protocol/axone-mcp/internal/version.Commit=$(COMMIT)
+	-X github.com/axone-protocol/axone-mcp/internal/version.Name=$(BINARY_NAME) \
+	-X github.com/axone-protocol/axone-mcp/internal/version.Version=$(VERSION)  \
+	-X github.com/axone-protocol/axone-mcp/internal/version.Commit=$(COMMIT)
 BUILD_FLAGS := -ldflags '$(LD_FLAGS)'
 GO_BUILD := CGO_ENABLED=0 go build $(BUILD_FLAGS)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,44 @@ flowchart LR
     s3Proxy -. ② ✅ access .-> s3
 ```
 
+## Usage
+
+Install the MCP server:
+
+```sh
+go install github.com/axone-protocol/axone-mcp@latest
+```
+
+### Usage with [Claude Desktop](https://claude.ai/download)
+
+Add this to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "axone-mcp",
+      "args": [
+        "serve",
+        "stdio"
+      ]
+    }
+  }
+}
+```
+
+### Run with SSE transport
+
+```sh
+axone-mcp serve sse --listen-addr localhost:8080
+```
+
+### Run with STDIO transport
+
+```sh
+axone-mcp serve stdio
+```
+
 ## Build
 
 - Be sure you have [Golang](https://go.dev/doc/install) installed.

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -25,10 +25,16 @@ var (
 func InstallLogRunE(_ *cobra.Command, _ []string) error {
 	var output io.Writer
 
-	switch format := strings.ToLower(logFormat); {
-	case format == "console" || (format == "auto" && isatty.IsTerminal(os.Stdout.Fd())):
+	switch strings.ToLower(logFormat) {
+	case "auto":
+		if isatty.IsTerminal(os.Stdout.Fd()) {
+			output = zerolog.ConsoleWriter{Out: os.Stderr}
+		} else {
+			output = os.Stderr
+		}
+	case "console":
 		output = zerolog.ConsoleWriter{Out: os.Stderr}
-	case format == "json":
+	case "json":
 		output = os.Stderr
 	default:
 		return fmt.Errorf("unknown log format: %s", logFormat)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,3 +22,7 @@ func Execute() {
 		os.Exit(1)
 	}
 }
+
+func init() {
+	cobra.EnableTraverseRunHooks = true
+}

--- a/cmd/serve-sse.go
+++ b/cmd/serve-sse.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"axone-protocol/axone-mcp/internal/mcp"
+
+	"github.com/justinas/alice"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/hlog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagBaseURL    = "base-url"
+	FlagListenAddr = "listen-addr"
+)
+
+const (
+	ReadHeaderTimeout = 5 * time.Second
+)
+
+var (
+	baseURL    string
+	listenAddr string
+)
+
+var serveSseCmd = &cobra.Command{
+	Use:   "sse",
+	Short: "Serve the MCP over SSE (server-sent events)",
+	Long: `Start the MCP server using Server-Sent Events (SSE) to enable streaming over HTTP.
+Typically used for browser-based or reactive clients.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		s, err := mcp.NewServer()
+		if err != nil {
+			return err
+		}
+
+		sseServer := server.NewSSEServer(s)
+		chain := loggerChain().Then(sseServer)
+		httpSrv := &http.Server{
+			Addr:              listenAddr,
+			ReadHeaderTimeout: ReadHeaderTimeout,
+			Handler:           chain,
+		}
+
+		go func() {
+			log.Logger.Info().
+				Str("transport", "sse").
+				Str("base_url", baseURL).
+				Str("addr", listenAddr).
+				Str("message_path", sseServer.CompleteMessagePath()).
+				Str("sse_path", sseServer.CompleteSsePath()).
+				Msg("ready")
+			if err := httpSrv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+				log.Fatal().Err(err).Msg("failed to start server")
+			}
+		}()
+
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		<-ctx.Done()
+		log.Info().Msg("shutdown signal received")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return sseServer.Shutdown(shutdownCtx)
+	},
+}
+
+func loggerChain() alice.Chain {
+	return alice.New(hlog.NewHandler(log.Logger),
+		hlog.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
+			zerolog.Ctx(r.Context()).
+				Debug().
+				Str("client", r.RemoteAddr).
+				Str("method", r.Method).
+				Stringer("path", r.URL).
+				Str("user_agent", r.Header.Get("User-Agent")).
+				Int("status", status).
+				Int("size", size).
+				Dur("duration", duration).
+				Msg("")
+		}),
+	)
+}
+
+func init() {
+	serveSseCmd.PersistentFlags().StringVar(&baseURL, FlagBaseURL, "", "The server's base URL")
+	serveSseCmd.PersistentFlags().StringVar(&listenAddr, FlagListenAddr, "127.0.0.1:8081", "The server's listen address")
+
+	serveCmd.AddCommand(serveSseCmd)
+}

--- a/cmd/serve-sse.go
+++ b/cmd/serve-sse.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"axone-protocol/axone-mcp/internal/mcp"
+	"github.com/axone-protocol/axone-mcp/internal/mcp"
 
 	"github.com/justinas/alice"
 

--- a/cmd/serve-stdio.go
+++ b/cmd/serve-stdio.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+
+	"axone-protocol/axone-mcp/internal/mcp"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var serveStdioCmd = &cobra.Command{
+	Use:   "stdio",
+	Short: "Serve the MCP over stdio (Standard Input/Output)",
+	Long: `Start the MCP server using standard input and output streams.
+This mode is typically used for local integrations and command-line tools that communicate via stdio.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		s, err := mcp.NewServer()
+		if err != nil {
+			return err
+		}
+
+		zlog.Logger.Info().
+			Str("transport", "stdio").
+			Msg("ready")
+
+		err = server.ServeStdio(s, WithZerolog())
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+
+		zlog.Info().Msg("shutdown signal received")
+
+		return nil
+	},
+}
+
+// WithZerolog configures the server to use zerolog for logging.
+func WithZerolog() server.StdioOption {
+	errorWriter := &logWriter{
+		logger: zlog.With().Logger(),
+	}
+
+	// Create a standard library logger that writes to our custom writer
+	stdLogger := log.New(errorWriter, "", 0)
+
+	return server.WithErrorLogger(stdLogger)
+}
+
+// logWriter implements io.Writer by writing to a zerolog.Logger.
+type logWriter struct {
+	logger zerolog.Logger
+}
+
+// Write implements io.Writer.
+func (w *logWriter) Write(p []byte) (n int, err error) {
+	// Remove trailing newlines and spaces for cleaner log output
+	msg := strings.TrimSpace(string(p))
+	if msg != "" {
+		w.logger.Error().Msg(msg)
+	}
+	return len(p), nil
+}
+
+func init() {
+	serveCmd.AddCommand(serveStdioCmd)
+}

--- a/cmd/serve-stdio.go
+++ b/cmd/serve-stdio.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	"axone-protocol/axone-mcp/internal/mcp"
+	"github.com/axone-protocol/axone-mcp/internal/mcp"
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog"

--- a/cmd/serve-stdio_test.go
+++ b/cmd/serve-stdio_test.go
@@ -1,0 +1,145 @@
+package cmd_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"axone-protocol/axone-mcp/internal/version"
+
+	"axone-protocol/axone-mcp/cmd"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const testTimeout = 5 * time.Second
+
+func TestServeStdioCommand(t *testing.T) {
+	Convey("Testing Serve Stdio command", t, func() {
+		tests := []struct {
+			name     string
+			input    string
+			expected string
+		}{
+			{
+				name:     "Ping",
+				input:    `{"jsonrpc": "2.0", "id": 42, "method": "ping", "params": {}}`,
+				expected: `{"jsonrpc":"2.0","id":42,"result":{}}`,
+			},
+			{
+				name:     "hello_world tool (ok)",
+				input:    `{"jsonrpc": "2.0", "id": 42, "method": "tools/call", "params": {"name": "hello_world", "arguments": {"name": "John"}}}`,
+				expected: `{"jsonrpc":"2.0","id":42,"result":{"content":[{"type":"text","text":"Hello, John!"}]}}`,
+			},
+		}
+		for _, tt := range tests {
+			Convey(fmt.Sprintf("Given a new server executed by serve stdio command for %s", tt.name),
+				withCommandArguments([]string{"serve", "stdio"},
+					withPipedIOStreams(func(c C, stdinW io.Writer, stdoutR io.Reader, stderrR io.Reader) {
+						go func() {
+							cmd.Execute()
+						}()
+
+						Convey(fmt.Sprintf("When sending input: %s", tt.input),
+							func(c C) {
+								go func() {
+									writer := bufio.NewWriter(stdinW)
+									_, err := fmt.Fprintf(writer, "%s\n", tt.input)
+									c.So(err, ShouldBeNil)
+									err = writer.Flush()
+									c.So(err, ShouldBeNil)
+								}()
+
+								Convey(fmt.Sprintf("Then the response should be: %s", tt.expected), func(c C) {
+									var got string
+									done := make(chan struct{})
+									go func() {
+										scanner := bufio.NewScanner(stdoutR)
+										scanner.Scan()
+										c.So(scanner.Err(), ShouldBeNil)
+										got = scanner.Text()
+										close(done)
+									}()
+
+									select {
+									case <-done:
+									case <-time.After(testTimeout):
+										buf := make([]byte, 1024)
+										_, _ = stdoutR.Read(buf)
+										t.Fatalf("timeout. partial stdout: %q", string(buf))
+									}
+
+									So(got, shouldJSONEqual, tt.expected)
+								})
+							})
+					})))
+		}
+	})
+}
+
+func withCommandArguments(args []string, f func(c C)) func(c C) {
+	return func(c C) {
+		origArgs := os.Args
+
+		Reset(func() {
+			os.Args = origArgs
+		})
+
+		os.Args = append([]string{version.Name}, args...)
+
+		f(c)
+	}
+}
+
+func withPipedIOStreams(f func(c C, stdinW io.Writer, stdoutR io.Reader, stderr io.Reader)) func(c C) {
+	return func(c C) {
+		stdinReader, stdinWriter := io.Pipe()
+		stdoutReader, stdoutWriter := io.Pipe()
+		stderrReader, stderrWriter := io.Pipe()
+
+		origStdin := cmd.MCPStdin
+		origStdout := cmd.MCPStdout
+		origStderr := cmd.MCPStderr
+
+		Reset(func() {
+			cmd.MCPStdin = origStdin
+			cmd.MCPStdout = origStdout
+			cmd.MCPStderr = origStderr
+
+			So(stdinWriter.Close(), ShouldBeNil)
+			So(stdoutWriter.Close(), ShouldBeNil)
+			So(stderrWriter.Close(), ShouldBeNil)
+		})
+
+		cmd.MCPStdin = stdinReader
+		cmd.MCPStdout = stdoutWriter
+		cmd.MCPStderr = stderrWriter
+
+		f(c, stdinWriter, stdoutReader, stderrReader)
+	}
+}
+
+func shouldJSONEqual(actual interface{}, expected ...interface{}) string {
+	if len(expected) != 1 {
+		return fmt.Sprintf("This assertion requires exactly %d comparison values (you provided %d).", 1, len(expected))
+	}
+
+	left, leftIsString := actual.(string)
+	right, rightIsString := expected[0].(string)
+
+	if !leftIsString || !rightIsString {
+		return fmt.Sprintf("Both arguments to this assertion must be strings (you provided %v and %v).", reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	var leftNormalized, rightNormalized bytes.Buffer
+	ShouldBeNil(json.Compact(&leftNormalized, []byte(left)))
+	ShouldBeNil(json.Compact(&rightNormalized, []byte(right)))
+
+	return ShouldEqual(leftNormalized.String(), rightNormalized.String())
+}

--- a/cmd/serve-stdio_test.go
+++ b/cmd/serve-stdio_test.go
@@ -11,9 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"axone-protocol/axone-mcp/internal/version"
-
-	"axone-protocol/axone-mcp/cmd"
+	"github.com/axone-protocol/axone-mcp/cmd"
+	"github.com/axone-protocol/axone-mcp/internal/version"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,103 +1,24 @@
 package cmd
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
-	"axone-protocol/axone-mcp/internal/mcp"
-
-	"github.com/justinas/alice"
-
-	"github.com/mark3labs/mcp-go/server"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/hlog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
-const (
-	FlagBaseURL    = "base-url"
-	FlagListenAddr = "listen-addr"
-)
-
-const (
-	ReadHeaderTimeout = 5 * time.Second
-)
-
-var (
-	baseURL    string
-	listenAddr string
-)
-
-var serveSseCmd = &cobra.Command{
-	Use:   "serve-sse",
-	Short: "Start the MCP server (SSE)",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		log.Logger.Info().Msg("starting server")
-
-		s, err := mcp.NewServer()
-		if err != nil {
-			return err
-		}
-
-		sseServer := server.NewSSEServer(s)
-		chain := loggerChain().Then(sseServer)
-		httpSrv := &http.Server{
-			Addr:              listenAddr,
-			ReadHeaderTimeout: ReadHeaderTimeout,
-			Handler:           chain,
-		}
-
-		go func() {
-			log.Logger.Info().
-				Str("transport", "sse").
-				Str("base_url", baseURL).
-				Str("addr", listenAddr).
-				Str("message_path", sseServer.CompleteMessagePath()).
-				Str("sse_path", sseServer.CompleteSsePath()).
-				Msg("listening for connections")
-			if err := httpSrv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-				log.Fatal().Err(err).Msg("failed to start server")
-			}
-		}()
-
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
-
-		<-ctx.Done()
-		log.Info().Msg("shutdown signal received")
-
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		return sseServer.Shutdown(shutdownCtx)
+// serveCmd represents the base serve command.
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve the MCP using a specific transport",
+	Long: `Start the Axone MCP server using the chosen transport:
+SSE for web clients, stdio for command-line and local integrations.`,
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		log.Logger.Info().Msg("starting server...")
+	},
+	PersistentPostRun: func(_ *cobra.Command, _ []string) {
+		log.Logger.Info().Msg("server stopped")
 	},
 }
 
-func loggerChain() alice.Chain {
-	return alice.New(hlog.NewHandler(log.Logger),
-		hlog.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
-			zerolog.Ctx(r.Context()).
-				Debug().
-				Str("client", r.RemoteAddr).
-				Str("method", r.Method).
-				Stringer("path", r.URL).
-				Str("user_agent", r.Header.Get("User-Agent")).
-				Int("status", status).
-				Int("size", size).
-				Dur("duration", duration).
-				Msg("")
-		}),
-	)
-}
-
 func init() {
-	serveSseCmd.PersistentFlags().StringVar(&baseURL, FlagBaseURL, "", "The server's base URL")
-	serveSseCmd.PersistentFlags().StringVar(&listenAddr, FlagListenAddr, "127.0.0.1:8081", "The server's listen address")
-
-	rootCmd.AddCommand(serveSseCmd)
+	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"axone-protocol/axone-mcp/internal/version"
+	"github.com/axone-protocol/axone-mcp/internal/version"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module axone-protocol/axone-mcp
+module github.com/axone-protocol/axone-mcp
 
 go 1.24
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,7 +20,9 @@ func NewServer() (*server.MCPServer, error) {
 	s := server.NewMCPServer(
 		ServerName,
 		version.Version,
-		WithLogging(),
+		server.WithLogging(),
+		server.WithToolCapabilities(false),
+		WithHooksLogging(),
 	)
 
 	tool := mcp.NewTool("hello_world",
@@ -36,13 +38,13 @@ func NewServer() (*server.MCPServer, error) {
 	return s, nil
 }
 
-func WithLogging() server.ServerOption {
+func WithHooksLogging() server.ServerOption {
 	hooks := &server.Hooks{}
 
 	hooks.AddOnRegisterSession(func(_ context.Context, session server.ClientSession) {
 		log.Logger.Info().
 			Str("session_id", session.SessionID()).
-			Msg("Session created")
+			Msg("session created")
 	})
 
 	return server.WithHooks(hooks)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"axone-protocol/axone-mcp/internal/version"
+	"github.com/axone-protocol/axone-mcp/internal/version"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -137,7 +137,7 @@ func TestOnRegisterSessionLog(t *testing.T) {
 
 			Convey("Then the session ID and creation message should appear in the logs", func() {
 				So(output, ShouldContainSubstring, "1234")
-				So(output, ShouldContainSubstring, "Session created")
+				So(output, ShouldContainSubstring, "session created")
 			})
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "axone-protocol/axone-mcp/cmd"
+import "github.com/axone-protocol/axone-mcp/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Implement [stdio transport](https://modelcontextprotocol.io/docs/concepts/transports#standard-input%2Foutput-stdio) for the MCP server alongside the existing [SSE transport](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse).

Command hierarchy has been refactored to group transports under `serve`: `serve sse`, `serve stdio`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new server commands that offer support for both Server-Sent Events (SSE) and STDIO transports for enhanced operational flexibility.

- **Documentation**
  - Added a detailed "Usage" section describing installation steps and configuration examples for a smoother setup experience.

- **Refactor**
  - Updated module naming and refined logging behavior to provide clearer runtime output.

- **Tests**
  - Expanded test coverage for the STDIO functionality to ensure robust and reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->