### PR TITLE
ci(workflow): fix release workflow by pinning correct tool versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,15 @@ jobs:
       - name: Release project
         uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 19.0.2
+          semantic_version: 22.0.5
           branch: main
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/exec
             @semantic-release/git
-            @google/semantic-release-replace-plugin
+            @google/semantic-release-replace-plugin@1.2.7
           extends: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@7.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.OPS_TOKEN }}
           GIT_AUTHOR_NAME: ${{ vars.BOT_GIT_AUTHOR_NAME }}


### PR DESCRIPTION
Fix the "Command failed" of the death during release by foolishly applying the exact recipe that works in [axone-sdk](https://github.com/axone-protocol/axone-sdk/blob/main/.github/workflows/release.yml), regardless of any newer versions that may exist.

<img width="985" alt="image" src="https://github.com/user-attachments/assets/4892d95b-f238-48df-aef4-885e56bcb7c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our release automation process by updating version requirements and streamlining dependency management.
  - These improvements help ensure smoother, more reliable, and timely product updates, ultimately supporting a better overall experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->