### PR TITLE
Feat/readonly tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mark3labs/mcp-go v0.26.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/rs/zerolog v1.34.0
+	github.com/samber/lo v1.50.0
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -705,6 +705,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/samber/lo v1.50.0 h1:XrG0xOeHs+4FQ8gJR97zDz5uOFMW7OwFWiFVzqopKgY=
+github.com/samber/lo v1.50.0/go.mod h1:RjZyNk6WSnUFRKK6EyOhsRJMqft3G+pg7dCWHQCWvsc=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=

--- a/internal/mcp/governance.go
+++ b/internal/mcp/governance.go
@@ -15,53 +15,59 @@ import (
 	"google.golang.org/grpc"
 )
 
-func getGovernanceCode(cc grpc.ClientConnInterface) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func getGovernanceCode(cc grpc.ClientConnInterface) server.ServerTool {
 	const dataverseAddressParam = "dataverse"
 	const resourceParam = "resource"
-	return mcp.NewTool("get_resource_governance_code",
-			mcp.WithDescription(`Get the governance code attached to the given resource (if any) in the given dataverse`),
-			mcp.WithString(dataverseAddressParam,
-				mcp.Required(),
-				mcp.Description("The address of the dataverse contract")),
-			mcp.WithString(resourceParam,
-				mcp.Required(),
-				mcp.Description("The DID URI of the resource")),
-		),
-		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			dataverseAddress, err := requiredParam[string](request, dataverseAddressParam)
-			if err != nil {
-				return nil, err
-			}
-
-			resourceDID, err := requiredParam[string](request, resourceParam)
-			if err != nil {
-				return nil, err
-			}
-
-			dataverseInfo, err := dataverse.Dataverse(ctx, cc, dataverseAddress, ref(dataverseschema.QueryMsg_Dataverse{}))
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			cognitariumAddress := string(dataverseInfo.TriplestoreAddress)
-			if cognitariumAddress == "" {
-				return mcp.NewToolResultError("no triplestore address found"), nil
-			}
-
-			lawstoneAddress, err := cognitarium.GetGovernanceAddressForResource(ctx, cc, cognitariumAddress, resourceDID)
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-			code, err := lawstone.ProgramCode(ctx, cc, lawstoneAddress, ref(lawstoneschema.QueryMsg_ProgramCode{}))
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			decodedCode, err := base64.StdEncoding.DecodeString(*code)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("failed to decode base64 code '%s': %v", *code, err)), nil
-			}
-
-			return mcp.NewToolResultText(string(decodedCode)), nil
+	tool := mcp.NewTool("get_resource_governance_code",
+		mcp.WithDescription(`Get the governance code attached to the given resource (if any) in the given dataverse`),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title:        "Get the governance code for a resource",
+			ReadOnlyHint: true,
+		}),
+		mcp.WithString(dataverseAddressParam,
+			mcp.Required(),
+			mcp.Description("The address of the dataverse contract")),
+		mcp.WithString(resourceParam,
+			mcp.Required(),
+			mcp.Description("The DID URI of the resource")),
+	)
+	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		dataverseAddress, err := requiredParam[string](request, dataverseAddressParam)
+		if err != nil {
+			return nil, err
 		}
+
+		resourceDID, err := requiredParam[string](request, resourceParam)
+		if err != nil {
+			return nil, err
+		}
+
+		dataverseInfo, err := dataverse.Dataverse(ctx, cc, dataverseAddress, ref(dataverseschema.QueryMsg_Dataverse{}))
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		cognitariumAddress := string(dataverseInfo.TriplestoreAddress)
+		if cognitariumAddress == "" {
+			return mcp.NewToolResultError("no triplestore address found"), nil
+		}
+
+		lawstoneAddress, err := cognitarium.GetGovernanceAddressForResource(ctx, cc, cognitariumAddress, resourceDID)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		code, err := lawstone.ProgramCode(ctx, cc, lawstoneAddress, ref(lawstoneschema.QueryMsg_ProgramCode{}))
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		decodedCode, err := base64.StdEncoding.DecodeString(*code)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to decode base64 code '%s': %v", *code, err)), nil
+		}
+
+		return mcp.NewToolResultText(string(decodedCode)), nil
+	}
+
+	return server.ServerTool{Tool: tool, Handler: handler}
 }

--- a/internal/mcp/governance_test.go
+++ b/internal/mcp/governance_test.go
@@ -346,7 +346,7 @@ func TestGovernanceJSONRCPMessageHandling(t *testing.T) {
 				if tt.fixture != nil {
 					tt.fixture(cc)
 				}
-				s, err := NewServer(cc)
+				s, err := NewServer(cc, ReadWrite)
 				So(err, ShouldBeNil)
 
 				messageBytes, err := json.Marshal(tt.message)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,30 +2,78 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/axone-protocol/axone-mcp/internal/version"
+	"github.com/mark3labs/mcp-go/mcp"
 	"google.golang.org/grpc"
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog/log"
+
+	"github.com/samber/lo"
 )
 
 const (
 	ServerName = "Axone MCP Server"
 )
 
-func NewServer(conn grpc.ClientConnInterface) (*server.MCPServer, error) {
+type AccessMode bool
+
+const (
+	ReadOnly  AccessMode = true
+	ReadWrite AccessMode = false
+)
+
+// NewServer creates a new MCP server instance.
+// It takes a gRPC connection to the Axone node and a read-only flag which  restricts the server to read-only operations.
+func NewServer(conn grpc.ClientConnInterface, mode AccessMode) (*server.MCPServer, error) {
 	s := server.NewMCPServer(
 		ServerName,
 		version.Version,
 		server.WithLogging(),
 		server.WithToolCapabilities(false),
+		server.WithToolFilter(func(_ context.Context, tools []mcp.Tool) []mcp.Tool {
+			return lo.Filter(tools, func(tool mcp.Tool, _ int) bool {
+				return mode != ReadOnly || tool.Annotations.ReadOnlyHint
+			})
+		}),
 		WithHooksLogging(),
 	)
 
-	s.AddTool(getGovernanceCode(conn))
+	addTools(s, mode,
+		getGovernanceCode(conn),
+	)
 
 	return s, nil
+}
+
+func addTools(s *server.MCPServer, mode AccessMode, tools ...server.ServerTool) {
+	s.AddTools(
+		wrapToolsWithAccessGuard(
+			mode,
+			tools,
+		)...)
+}
+
+func wrapToolsWithAccessGuard(mode AccessMode, tools []server.ServerTool) []server.ServerTool {
+	return lo.Map(tools, func(t server.ServerTool, _ int) server.ServerTool {
+		return wrapToolWithAccessGuard(mode, t)
+	})
+}
+
+func wrapToolWithAccessGuard(mode AccessMode, srvTool server.ServerTool) server.ServerTool {
+	next := srvTool.Handler
+	srvTool.Handler = func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if mode == ReadOnly && !srvTool.Tool.Annotations.ReadOnlyHint {
+			return mcp.NewToolResultError(
+				fmt.Sprintf("The server is in read-only mode; tool %s cannot be invoked.", srvTool.Tool.Name),
+			), nil
+		}
+		return next(ctx, request)
+	}
+
+	return srvTool
 }
 
 func WithHooksLogging() server.ServerOption {


### PR DESCRIPTION
This PR introduces a `--read-only` CLI flag to restrict the MCP server to read-only operations.

When enabled:
- Tools not explicitly marked with `ReadOnlyHint=true` are blocked from execution. If such a tool is invoked, the server returns an appropriate error.
- The tool listing endpoint ([tools/list](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#listing-tools) only returns tools compatible with read-only mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to run the server in read-only mode, restricting operations to non-modifying actions.

- **Bug Fixes**
  - Improved access control to ensure non-read-only tools cannot be invoked when the server is in read-only mode.

- **Tests**
  - Enhanced test coverage for read-only mode, including validation of tool visibility and invocation restrictions.

- **Chores**
  - Updated dependencies to include a new library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->