### PR TITLE
feat(mcp): set open world hint to true in get_resource_governance_code

### DIFF
--- a/internal/mcp/governance.go
+++ b/internal/mcp/governance.go
@@ -21,8 +21,9 @@ func getGovernanceCode(cc grpc.ClientConnInterface) server.ServerTool {
 	tool := mcp.NewTool("get_resource_governance_code",
 		mcp.WithDescription(`Get the governance code attached to the given resource (if any) in the given dataverse`),
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
-			Title:        "Get the governance code for a resource",
-			ReadOnlyHint: ref(true),
+			Title:         "Get the governance code for a resource",
+			ReadOnlyHint:  mcp.ToBoolPtr(true),
+			OpenWorldHint: mcp.ToBoolPtr(true),
 		}),
 		mcp.WithString(dataverseAddressParam,
 			mcp.Required(),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -24,7 +24,7 @@ func TestJSONRCPMessageHandling(t *testing.T) {
 		Tool: mcp.NewTool("read_write_foo",
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        "ReadWriteFoo",
-				ReadOnlyHint: ref(false),
+				ReadOnlyHint: mcp.ToBoolPtr(false),
 			})),
 		Handler: func(ctx goctx.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			t.Fatalf("read_write_foo tool shouldn't be called")


### PR DESCRIPTION
Set the [Open World Hint annotation](https://modelcontextprotocol.io/docs/concepts/tools#available-tool-annotations) to `true` for the `get_resource_governance_code` tool, indicating that it interacts with an external system, in our case, the [Axone blockchain](https://axone.xyz).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal handling of tool annotation fields for improved consistency.
- **Tests**
	- Adjusted test setup to use a standardized method for setting boolean pointer values in tool annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->