### PR TITLE
docs: document the get_dataverse_info tool

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,3 @@
 line-length: false
 no-hard-tabs: false
+no-duplicate-header: false

--- a/README.md
+++ b/README.md
@@ -40,13 +40,27 @@ flowchart LR
     mcpServer:::system@{ shape: rounded, label: "Axone<br>MCP server" }
     axone:::system@{ shape: das, label: "🔗 Axone chain" }
 
-
     actor -- query --> mcpServer
 
     mcpServer -. query .-> axone
 ```
 
 ## Available tools
+
+### `get_dataverse_info`
+
+Get information about the given dataverse.
+
+#### Input schema
+
+```json
+{
+  "dataverse": {
+    "type": "string",
+    "description": "The address of the dataverse contract"
+  }
+}
+```
 
 ### `get_resource_governance_code`
 


### PR DESCRIPTION
The server registers two tools (`internal/mcp/server.go`: `getDataverse` and `getGovernanceCode`), but the README's "Available tools" section only documents `get_resource_governance_code`. This adds the missing `get_dataverse_info` entry, with the input schema matching `internal/mcp/dataverse.go` (a required `dataverse` string: the address of the dataverse contract).

Part of #892.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README documentation for the `get_dataverse_info` tool, including its purpose and required dataverse contract address input.
* **Chores**
  * Updated Markdown linting configuration to allow duplicate headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->