### PR TITLE
fix: correct smithery launch command (add serve stdio, drop unknown --dataverse-addr flag)

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,23 +6,18 @@ startCommand:
     type: object
     required:
       - nodeGrpc
-      - dataverseAddr
     properties:
       nodeGrpc:
         type: string
         default: grpc.dentrite.axone.xyz:443
         description: Address <host>:<port> of the gRPC endpoint exposed by the axone node.
-      dataverseAddr:
-        type: string
-        default: axone1xt4ahzz2x8hpkc0tk6ekte9x6crw4w6u0r67cyt3kz9syh24pd7scvlt2w
-        description: Address of the dataverse CosmWasm contract.
   commandFunction: |-
     (config) => ({
       command: "/usr/bin/axone-mcp",
       args: [
+        "serve",
+        "stdio",
         "--node-grpc",
         config.nodeGrpc,
-        "--dataverse-addr",
-        config.dataverseAddr,
       ],
     });


### PR DESCRIPTION
Launching the server via Smithery currently fails for two reasons:

1. The command passes `--dataverse-addr`, which is not a CLI flag. `cmd/serve.go` only defines `--node-grpc`, `--grpc-no-tls`, `--grpc-tls-skip-verify`, `--grpc-timeout` and `--read-only`. The dataverse address is a per-tool-call parameter, so cobra rejects it with an unknown-flag error.
2. The command is missing the `serve stdio` subcommands. The binary is invoked as `axone-mcp serve stdio --node-grpc ...` (per the README), but `commandFunction` runs `axone-mcp --node-grpc ...`.

This PR drops the non-existent flag (and its `dataverseAddr` config entry) and adds `serve stdio`, so a Smithery launch actually starts the server.

Note: the default `nodeGrpc` still points at the deprecated `dentrite` testnet; that's tracked separately in #892 (no public `dendrite-2` gRPC endpoint is published yet), so it's left unchanged here.

Part of #892.
